### PR TITLE
Fix packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,14 @@ Python CLI tool to convert SVG files to draw.io shape library
 ## Usage
 
 ```bash
-python3 src/app.py --help
-```
-
-or
-
-```bash
+pip install -e .
 svg2drawiolib --help
 ```
 
 ```text
-usage: app.py [-h] [--mode {data,xml}] [--output OUTPUT] [--style STYLE] [--width WIDTH]
-              [--height HEIGHT] [--prefix PREFIX] [--dirtitle] [--log-level LOG_LEVEL]
-              [input ...]
+usage: svg2drawiolib [-h] [--mode {data,xml}] [--output OUTPUT] [--style STYLE] [--width WIDTH]
+                     [--height HEIGHT] [--prefix PREFIX] [--dirtitle] [--log-level LOG_LEVEL]
+                     [input ...]
 ```
 
 ### input parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,12 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "svg2drawiolib"
 version = "0.0.1"
+license = "Apache-2.0"
+dependencies = []
 
 [project.scripts]
-svg2drawiolib = "app:_main"
+svg2drawiolib = "svg2drawiolib.__main__:main"

--- a/src/svg2drawiolib/__main__.py
+++ b/src/svg2drawiolib/__main__.py
@@ -47,7 +47,7 @@ def _setup_argparse():
 
     return args
 
-def _main():
+def main():
     args = _setup_argparse()
     logging.basicConfig(level=args.log_level)
 
@@ -58,4 +58,4 @@ def _main():
         text_file.write(output_str)
 
 if __name__ == '__main__':
-    _main()
+    main()


### PR DESCRIPTION
* Moves `app.py` to be `__main__.py` inside the package
  * Since the package has no deps, running `python -m svg2drawiolib` from inside `src/` will also work.
* Adds the required PEP517 fields to `pyproject.toml` so package can be installed
